### PR TITLE
[WIP] Expose Tail Kind to LLVM Dialect

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5750,9 +5750,9 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
   // Set tail call kind if necessary.
   if (llvm::CallInst *Call = dyn_cast<llvm::CallInst>(CI)) {
     if (TargetDecl && TargetDecl->hasAttr<NotTailCalledAttr>())
-      Call->setTailCallKind(llvm::CallInst::TCK_NoTail);
+      Call->setTailCallKind(llvm::TailCallKind::NoTail);
     else if (IsMustTail)
-      Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+      Call->setTailCallKind(llvm::TailCallKind::MustTail);
   }
 
   // Add metadata for calls to MSAllocator functions

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -2168,7 +2168,7 @@ static llvm::Function *getARCIntrinsic(llvm::Intrinsic::ID IntID,
 static llvm::Value *emitARCValueOperation(
     CodeGenFunction &CGF, llvm::Value *value, llvm::Type *returnType,
     llvm::Function *&fn, llvm::Intrinsic::ID IntID,
-    llvm::CallInst::TailCallKind tailKind = llvm::CallInst::TCK_None) {
+    llvm::TailCallKind::ID tailKind = llvm::TailCallKind::None) {
   if (isa<llvm::ConstantPointerNull>(value))
     return value;
 
@@ -2403,8 +2403,8 @@ static llvm::Value *emitOptimizedARCReturnCall(llvm::Value *value,
 
   bool isNoTail =
       CGF.CGM.getTargetCodeGenInfo().markARCOptimizedReturnCallsAsNoTail();
-  llvm::CallInst::TailCallKind tailKind =
-      isNoTail ? llvm::CallInst::TCK_NoTail : llvm::CallInst::TCK_None;
+  llvm::TailCallKind::ID tailKind =
+      isNoTail ? llvm::TailCallKind::NoTail : llvm::TailCallKind::None;
   return emitARCValueOperation(CGF, value, nullptr, EP, IID, tailKind);
 }
 
@@ -2544,7 +2544,7 @@ CodeGenFunction::EmitARCAutoreleaseReturnValue(llvm::Value *value) {
   return emitARCValueOperation(*this, value, nullptr,
                             CGM.getObjCEntrypoints().objc_autoreleaseReturnValue,
                                llvm::Intrinsic::objc_autoreleaseReturnValue,
-                               llvm::CallInst::TCK_Tail);
+                               llvm::TailCallKind::Tail);
 }
 
 /// Do a fused retain/autorelease of the given object.
@@ -2554,7 +2554,7 @@ CodeGenFunction::EmitARCRetainAutoreleaseReturnValue(llvm::Value *value) {
   return emitARCValueOperation(*this, value, nullptr,
                      CGM.getObjCEntrypoints().objc_retainAutoreleaseReturnValue,
                              llvm::Intrinsic::objc_retainAutoreleaseReturnValue,
-                               llvm::CallInst::TCK_Tail);
+                               llvm::TailCallKind::Tail);
 }
 
 /// Do a fused retain/autorelease of the given object.

--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -394,7 +394,7 @@ void CodeGenFunction::EmitCallAndReturnForThunk(llvm::FunctionCallee Callee,
   if (Thunk && !Thunk->Return.isEmpty())
     RV = PerformReturnAdjustment(*this, ResultType, RV, *Thunk);
   else if (llvm::CallInst* Call = dyn_cast<llvm::CallInst>(CallOrInvoke))
-    Call->setTailCallKind(llvm::CallInst::TCK_Tail);
+    Call->setTailCallKind(llvm::TailCallKind::Tail);
 
   // Emit return.
   if (!ResultType->isVoidType() && Slot.isNull())
@@ -436,7 +436,7 @@ void CodeGenFunction::EmitMustTailThunk(GlobalDecl GD,
   // Emit the musttail call manually.  Even if the prologue pushed cleanups, we
   // don't actually want to run them.
   llvm::CallInst *Call = Builder.CreateCall(Callee, Args);
-  Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+  Call->setTailCallKind(llvm::TailCallKind::Tail);
 
   // Apply the standard set of call attributes.
   unsigned CallingConv;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2832,7 +2832,7 @@ static void CreateMultiVersionResolverReturn(CodeGenModule &CGM,
       llvm::make_pointer_range(Resolver->args()));
 
   llvm::CallInst *Result = Builder.CreateCall(FuncToReturn, Args);
-  Result->setTailCallKind(llvm::CallInst::TCK_MustTail);
+  Result->setTailCallKind(llvm::TailCallKind::MustTail);
 
   if (Resolver->getReturnType()->isVoidTy())
     Builder.CreateRetVoid();

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -652,7 +652,7 @@ namespace llvm {
     int parsePHI(Instruction *&Inst, PerFunctionState &PFS);
     bool parseLandingPad(Instruction *&Inst, PerFunctionState &PFS);
     bool parseCall(Instruction *&Inst, PerFunctionState &PFS,
-                   CallInst::TailCallKind TCK);
+                   TailCallKind::ID TCK);
     int parseAlloc(Instruction *&Inst, PerFunctionState &PFS);
     int parseLoad(Instruction *&Inst, PerFunctionState &PFS);
     int parseStore(Instruction *&Inst, PerFunctionState &PFS);

--- a/llvm/include/llvm/IR/TailCallKind.h
+++ b/llvm/include/llvm/IR/TailCallKind.h
@@ -1,0 +1,41 @@
+//===- llvm/TailCallKind.h - LLVM Tail Call Kind ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines LLVM's set of tail call kinds.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IR_TAILCALLKIND_H
+#define LLVM_IR_TAILCALLKIND_H
+
+namespace llvm {
+
+/// TailCallKind Namespace - This namespace contains an enum with a value for
+/// the tail call kinds.
+///
+namespace TailCallKind {
+
+/// LLVM IR allows to use arbitrary numbers as calling convention identifiers.
+using ID = unsigned;
+
+/// A set of enums which specify the assigned numeric values for known llvm
+/// calling conventions.
+/// Note that 'musttail' implies 'tail'.
+enum {
+  None = 0,
+  Tail = 1,
+  MustTail = 2,
+  NoTail = 3,
+  Last = NoTail
+};
+
+} // end namespace TailCallKind
+
+} // end namespace llvm
+
+#endif // LLVM_IR_TAILCALLKIND_H

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -7012,13 +7012,13 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     return parseFreeze(Inst, PFS);
   // Call.
   case lltok::kw_call:
-    return parseCall(Inst, PFS, CallInst::TCK_None);
+    return parseCall(Inst, PFS, TailCallKind::None);
   case lltok::kw_tail:
-    return parseCall(Inst, PFS, CallInst::TCK_Tail);
+    return parseCall(Inst, PFS, TailCallKind::Tail);
   case lltok::kw_musttail:
-    return parseCall(Inst, PFS, CallInst::TCK_MustTail);
+    return parseCall(Inst, PFS, TailCallKind::MustTail);
   case lltok::kw_notail:
-    return parseCall(Inst, PFS, CallInst::TCK_NoTail);
+    return parseCall(Inst, PFS, TailCallKind::NoTail);
   // Memory.
   case lltok::kw_alloca:
     return parseAlloc(Inst, PFS);
@@ -7964,7 +7964,7 @@ bool LLParser::parseFreeze(Instruction *&Inst, PerFunctionState &PFS) {
 ///   ::= 'notail' 'call'  OptionalFastMathFlags OptionalCallingConv
 ///           OptionalAttrs Type Value ParameterList OptionalAttrs
 bool LLParser::parseCall(Instruction *&Inst, PerFunctionState &PFS,
-                         CallInst::TailCallKind TCK) {
+                         TailCallKind::ID TCK) {
   AttrBuilder RetAttrs(M->getContext()), FnAttrs(M->getContext());
   std::vector<unsigned> FwdRefAttrGrps;
   LocTy BuiltinLoc;
@@ -7977,7 +7977,7 @@ bool LLParser::parseCall(Instruction *&Inst, PerFunctionState &PFS,
   SmallVector<OperandBundleDef, 2> BundleList;
   LocTy CallLoc = Lex.getLoc();
 
-  if (TCK != CallInst::TCK_None &&
+  if (TCK != TailCallKind::None &&
       parseToken(lltok::kw_call,
                  "expected 'tail call', 'musttail call', or 'notail call'"))
     return true;
@@ -7988,7 +7988,7 @@ bool LLParser::parseCall(Instruction *&Inst, PerFunctionState &PFS,
       parseOptionalProgramAddrSpace(CallAddrSpace) ||
       parseType(RetType, RetTypeLoc, true /*void allowed*/) ||
       parseValID(CalleeID, &PFS) ||
-      parseParameterList(ArgList, PFS, TCK == CallInst::TCK_MustTail,
+      parseParameterList(ArgList, PFS, TCK == TailCallKind::MustTail,
                          PFS.getFunction().isVarArg()) ||
       parseFnAttributeValuePairs(FnAttrs, FwdRefAttrGrps, false, BuiltinLoc) ||
       parseOptionalOperandBundles(BundleList, PFS))

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -6702,13 +6702,13 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       InstructionList.push_back(I);
       cast<CallInst>(I)->setCallingConv(
           static_cast<CallingConv::ID>((0x7ff & CCInfo) >> bitc::CALL_CCONV));
-      CallInst::TailCallKind TCK = CallInst::TCK_None;
+      TailCallKind::ID TCK = TailCallKind::None;
       if (CCInfo & (1 << bitc::CALL_TAIL))
-        TCK = CallInst::TCK_Tail;
+        TCK = TailCallKind::Tail;
       if (CCInfo & (1 << bitc::CALL_MUSTTAIL))
-        TCK = CallInst::TCK_MustTail;
+        TCK = TailCallKind::MustTail;
       if (CCInfo & (1 << bitc::CALL_NOTAIL))
-        TCK = CallInst::TCK_NoTail;
+        TCK = TailCallKind::NoTail;
       cast<CallInst>(I)->setTailCallKind(TCK);
       cast<CallInst>(I)->setAttributes(PAL);
       if (isa<DbgInfoIntrinsic>(I))

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3005,7 +3005,7 @@ LLVMTailCallKind LLVMGetTailCallKind(LLVMValueRef Call) {
 }
 
 void LLVMSetTailCallKind(LLVMValueRef Call, LLVMTailCallKind kind) {
-  unwrap<CallInst>(Call)->setTailCallKind((CallInst::TailCallKind)kind);
+  unwrap<CallInst>(Call)->setTailCallKind((TailCallKind::ID)kind);
 }
 
 /*--.. Operations on invoke instructions (only) ............................--*/

--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -655,7 +655,7 @@ Function *AArch64Arm64ECCallLowering::buildGuestExitThunk(Function *F) {
   for (Argument &Arg : GuestExit->args())
     Args.push_back(&Arg);
   CallInst *Call = B.CreateCall(Arm64Ty, GuardRetVal, Args);
-  Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+  Call->setTailCallKind(TailCallKind::MustTail);
 
   if (Call->getType()->isVoidTy())
     B.CreateRetVoid();

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1092,7 +1092,7 @@ void CoroCloner::create() {
     if (TTI.supportsTailCallFor(ResumeCall)) {
       // FIXME: Could we support symmetric transfer effectively without
       // musttail?
-      ResumeCall->setTailCallKind(CallInst::TCK_MustTail);
+      ResumeCall->setTailCallKind(TailCallKind::MustTail);
     }
 
     // Put a 'ret void' after the call, and split any remaining instructions to
@@ -1667,7 +1667,7 @@ CallInst *coro::createMustTailCall(DebugLoc Loc, Function *MustTailCallFn,
   auto *TailCall = Builder.CreateCall(FnTy, MustTailCallFn, CallArgs);
   // Skip targets which don't support tail call.
   if (TTI.supportsTailCallFor(TailCall)) {
-    TailCall->setTailCallKind(CallInst::TCK_MustTail);
+    TailCall->setTailCallKind(TailCallKind::MustTail);
   }
   TailCall->setDebugLoc(Loc);
   TailCall->setCallingConv(MustTailCallFn->getCallingConv());

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -811,12 +811,12 @@ bool ExpandVariadics::expandCall(Module &M, IRBuilder<> &Builder, CallBase *CB,
 
     NewCB = CallInst::Create(NFTy, Dst, Args, OpBundles, "", CI);
 
-    CallInst::TailCallKind TCK = CI->getTailCallKind();
-    assert(TCK != CallInst::TCK_MustTail);
+    TailCallKind::ID TCK = CI->getTailCallKind();
+    assert(TCK != TailCallKind::MustTail);
 
     // Can't tail call a function that is being passed a pointer to an alloca
-    if (TCK == CallInst::TCK_Tail)
-      TCK = CallInst::TCK_None;
+    if (TCK == TailCallKind::Tail)
+      TCK = TailCallKind::None;
     CI->setTailCallKind(TCK);
 
   } else {

--- a/llvm/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/llvm/lib/Transforms/IPO/MergeFunctions.cpp
@@ -769,8 +769,8 @@ void MergeFunctions::writeThunk(Function *F, Function *G) {
   ReturnInst *RI = nullptr;
   bool isSwiftTailCall = F->getCallingConv() == CallingConv::SwiftTail &&
                          G->getCallingConv() == CallingConv::SwiftTail;
-  CI->setTailCallKind(isSwiftTailCall ? llvm::CallInst::TCK_MustTail
-                                      : llvm::CallInst::TCK_Tail);
+  CI->setTailCallKind(isSwiftTailCall ? TailCallKind::MustTail
+                                      : TailCallKind::Tail);
   CI->setCallingConv(F->getCallingConv());
   CI->setAttributes(F->getAttributes());
   if (H->getReturnType()->isVoidTy()) {

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1438,7 +1438,7 @@ void DevirtModule::tryICallBranchFunnel(
       Intrinsic::getDeclaration(&M, llvm::Intrinsic::icall_branch_funnel, {});
 
   auto *CI = CallInst::Create(Intr, JTArgs, "", BB);
-  CI->setTailCallKind(CallInst::TCK_MustTail);
+  CI->setTailCallKind(TailCallKind::MustTail);
   ReturnInst::Create(M.getContext(), nullptr, BB);
 
   bool IsExported = false;

--- a/llvm/lib/Transforms/ObjCARC/ObjCARC.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARC.cpp
@@ -100,7 +100,7 @@ BundledRetainClaimRVs::~BundledRetainClaimRVs() {
       // calls. Mark them as notail so that the backend knows these calls
       // can't be tail calls.
       if (auto *CI = dyn_cast<CallInst>(CB))
-        CI->setTailCallKind(CallInst::TCK_NoTail);
+        CI->setTailCallKind(TailCallKind::NoTail);
     }
 
     EraseInstruction(P.first);

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2541,13 +2541,13 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
 
   bool InlinedMustTailCalls = false, InlinedDeoptimizeCalls = false;
   if (InlinedFunctionInfo.ContainsCalls) {
-    CallInst::TailCallKind CallSiteTailKind = CallInst::TCK_None;
+    TailCallKind::ID CallSiteTailKind = TailCallKind::None;
     if (CallInst *CI = dyn_cast<CallInst>(&CB))
       CallSiteTailKind = CI->getTailCallKind();
 
     // For inlining purposes, the "notail" marker is the same as no marker.
-    if (CallSiteTailKind == CallInst::TCK_NoTail)
-      CallSiteTailKind = CallInst::TCK_None;
+    if (CallSiteTailKind == TailCallKind::NoTail)
+      CallSiteTailKind = TailCallKind::None;
 
     for (Function::iterator BB = FirstNewBlock, E = Caller->end(); BB != E;
          ++BB) {
@@ -2607,8 +2607,8 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
         //    f ->          g ->     tail f  ==>  f ->          f
         //
         // Inlined notail calls should remain notail calls.
-        CallInst::TailCallKind ChildTCK = CI->getTailCallKind();
-        if (ChildTCK != CallInst::TCK_NoTail)
+        TailCallKind::ID ChildTCK = CI->getTailCallKind();
+        if (ChildTCK != TailCallKind::NoTail)
           ChildTCK = std::min(CallSiteTailKind, ChildTCK);
         CI->setTailCallKind(ChildTCK);
         InlinedMustTailCalls |= CI->isMustTailCall();

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -727,14 +727,14 @@ TEST(InstructionsTest, CloneCall) {
       CallInst::Create(FnTy, Callee, Args, "result"));
 
   // Test cloning the tail call kind.
-  CallInst::TailCallKind Kinds[] = {CallInst::TCK_None, CallInst::TCK_Tail,
-                                    CallInst::TCK_MustTail};
-  for (CallInst::TailCallKind TCK : Kinds) {
+  TailCallKind::ID Kinds[] = {TailCallKind::None, TailCallKind::Tail,
+                                    TailCallKind::MustTail};
+  for (TailCallKind::ID TCK : Kinds) {
     Call->setTailCallKind(TCK);
     std::unique_ptr<CallInst> Clone(cast<CallInst>(Call->clone()));
     EXPECT_EQ(Call->getTailCallKind(), Clone->getTailCallKind());
   }
-  Call->setTailCallKind(CallInst::TCK_None);
+  Call->setTailCallKind(TailCallKind::None);
 
   // Test cloning an attribute.
   {

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1077,4 +1077,13 @@ def LLVM_PoisonAttr : LLVM_Attr<"Poison", "poison">;
 /// Folded into from LLVM::ZeroOp.
 def LLVM_ZeroAttr : LLVM_Attr<"Zero", "zero">;
 
+//===----------------------------------------------------------------------===//
+// TailCallKindAttr
+//===----------------------------------------------------------------------===//
+
+def TailCallKindAttr : LLVM_Attr<"TailCallKind", "tailcallkind"> {
+  let parameters = (ins "TailCallKind":$TailCallKind);
+  let assemblyFormat = "`<` $TailCallKind `>`";
+}
+
 #endif // LLVMIR_ATTRDEFS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
@@ -89,6 +89,7 @@ public:
 // TODO: this shouldn't be needed after we unify the attribute generation, i.e.
 // --gen-attr-* and --gen-attrdef-*.
 using cconv::CConv;
+using tailcallkind::TailCallKind;
 using linkage::Linkage;
 } // namespace LLVM
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -280,6 +280,35 @@ def CConv : DialectAttr<
 }
 
 //===----------------------------------------------------------------------===//
+// TailCallKind
+//===----------------------------------------------------------------------===//
+
+def TailCallKindNone : LLVM_EnumAttrCase<"None", "none", "None", 0>;
+def TailCallKindTail : LLVM_EnumAttrCase<"Tail", "tail", "Tail", 1>;
+def TailCallKindMustTail : LLVM_EnumAttrCase<"MustTail", "musttail", "MustTail", 2>;
+def TailCallKindNoTailCall : LLVM_EnumAttrCase<"NoTail", "notail", "NoTail", 3>;
+
+def TailCallKindEnum : LLVM_CEnumAttr<
+    "TailCallKind",
+    "::llvm::TailCallKind",
+    "Tail Call Kind",
+    [TailCallKindNone, TailCallKindNoTailCall,
+    TailCallKindMustTail, TailCallKindTail]> {
+  let cppNamespace = "::mlir::LLVM::tailcallkind";
+}
+
+def TailCallKind : DialectAttr<
+    LLVM_Dialect,
+    CPred<"::llvm::isa<::mlir::LLVM::TailCallKindAttr>($_self)">,
+    "LLVM Calling Convention specification"> {
+  let storageType = "::mlir::LLVM::TailCallKindAttr";
+  let returnType = "::mlir::LLVM::tailcallkind::TailCallKind";
+  let convertFromStorage = "$_self.getTailCallKind()";
+  let constBuilderCall =
+          "::mlir::LLVM::TailCallKindAttr::get($_builder.getContext(), $0)";
+}
+
+//===----------------------------------------------------------------------===//
 // DIEmissionKind
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -650,7 +650,8 @@ def LLVM_CallOp : LLVM_MemAccessOpBase<"call",
                   DefaultValuedAttr<LLVM_FastmathFlagsAttr,
                                    "{}">:$fastmathFlags,
                   OptionalAttr<DenseI32ArrayAttr>:$branch_weights,
-                  DefaultValuedAttr<CConv, "CConv::C">:$CConv);
+                  DefaultValuedAttr<CConv, "CConv::C">:$CConv,
+                  DefaultValuedAttr<TailCallKind, "TailCallKind::None">:$TailCallKind);
   // Append the aliasing related attributes defined in LLVM_MemAccessOpBase.
   let arguments = !con(args, aliasAttrs);
   let results = (outs Optional<LLVM_Type>:$result);

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -43,6 +43,7 @@
 using namespace mlir;
 using namespace mlir::LLVM;
 using mlir::LLVM::cconv::getMaxEnumValForCConv;
+using mlir::LLVM::tailcallkind::getMaxEnumValForTailCallKind;
 using mlir::LLVM::linkage::getMaxEnumValForLinkage;
 
 #include "mlir/Dialect/LLVMIR/LLVMOpsDialect.cpp.inc"
@@ -197,6 +198,7 @@ struct EnumTraits {};
 REGISTER_ENUM_TYPE(Linkage);
 REGISTER_ENUM_TYPE(UnnamedAddr);
 REGISTER_ENUM_TYPE(CConv);
+REGISTER_ENUM_TYPE(TailCallKind);
 REGISTER_ENUM_TYPE(Visibility);
 } // namespace
 
@@ -974,7 +976,7 @@ void CallOp::build(OpBuilder &builder, OperationState &state, TypeRange results,
   build(builder, state, results,
         TypeAttr::get(getLLVMFuncType(builder.getContext(), results, args)),
         callee, args, /*fastmathFlags=*/nullptr, /*branch_weights=*/nullptr,
-        /*CConv=*/nullptr,
+        /*CConv=*/nullptr, /*TailCallKind=*/nullptr,
         /*access_groups=*/nullptr, /*alias_scopes=*/nullptr,
         /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr);
 }
@@ -996,7 +998,7 @@ void CallOp::build(OpBuilder &builder, OperationState &state,
                    ValueRange args) {
   build(builder, state, getCallOpResultTypes(calleeType),
         TypeAttr::get(calleeType), callee, args, /*fastmathFlags=*/nullptr,
-        /*branch_weights=*/nullptr, /*CConv=*/nullptr,
+        /*branch_weights=*/nullptr, /*CConv=*/nullptr, /*TailCallKind=*/nullptr,
         /*access_groups=*/nullptr,
         /*alias_scopes=*/nullptr, /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr);
 }
@@ -1006,7 +1008,7 @@ void CallOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, getCallOpResultTypes(calleeType),
         TypeAttr::get(calleeType), /*callee=*/nullptr, args,
         /*fastmathFlags=*/nullptr, /*branch_weights=*/nullptr,
-        /*CConv=*/nullptr,
+        /*CConv=*/nullptr, /*TailCallKind=*/nullptr,
         /*access_groups=*/nullptr, /*alias_scopes=*/nullptr,
         /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr);
 }
@@ -1017,7 +1019,7 @@ void CallOp::build(OpBuilder &builder, OperationState &state, LLVMFuncOp func,
   build(builder, state, getCallOpResultTypes(calleeType),
         TypeAttr::get(calleeType), SymbolRefAttr::get(func), args,
         /*fastmathFlags=*/nullptr, /*branch_weights=*/nullptr,
-        /*CConv=*/nullptr,
+        /*CConv=*/nullptr, /*TailCallKind=*/nullptr,
         /*access_groups=*/nullptr, /*alias_scopes=*/nullptr,
         /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr);
 }
@@ -1180,6 +1182,9 @@ void CallOp::print(OpAsmPrinter &p) {
   if (getCConv() != LLVM::CConv::C)
     p << stringifyCConv(getCConv()) << ' ';
 
+  if(getTailCallKind() != LLVM::TailCallKind::None)
+    p << tailcallkind::stringifyTailCallKind(getTailCallKind()) << ' ';
+
   // Print the direct callee if present as a function attribute, or an indirect
   // callee (first operand) otherwise.
   if (isDirect)
@@ -1194,7 +1199,7 @@ void CallOp::print(OpAsmPrinter &p) {
     p << " vararg(" << calleeType << ")";
 
   p.printOptionalAttrDict(processFMFAttr((*this)->getAttrs()),
-                          {getCConvAttrName(), "callee", "callee_type"});
+                          {getCConvAttrName(), "callee", "callee_type", getTailCallKindAttrName()});
 
   p << " : ";
   if (!isDirect)
@@ -1262,7 +1267,7 @@ static ParseResult parseOptionalCallFuncPtr(
   return success();
 }
 
-// <operation> ::= `llvm.call` (cconv)? (function-id | ssa-use)
+// <operation> ::= `llvm.call` (cconv)? (tailcallkind)? (function-id | ssa-use)
 //                             `(` ssa-use-list `)`
 //                             ( `vararg(` var-arg-func-type `)` )?
 //                             attribute-dict? `:` (type `,`)? function-type
@@ -1276,6 +1281,11 @@ ParseResult CallOp::parse(OpAsmParser &parser, OperationState &result) {
       getCConvAttrName(result.name),
       CConvAttr::get(parser.getContext(), parseOptionalLLVMKeyword<CConv>(
                                               parser, result, LLVM::CConv::C)));
+
+  result.addAttribute(
+      getTailCallKindAttrName(result.name),
+      TailCallKindAttr::get(parser.getContext(), parseOptionalLLVMKeyword<TailCallKind>(
+                                                     parser, result, LLVM::TailCallKind::None)));
 
   // Parse a function pointer for indirect calls.
   if (parseOptionalCallFuncPtr(parser, operands))

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -218,6 +218,7 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
                                 operandsRef.drop_front());
     }
     call->setCallingConv(convertCConvToLLVM(callOp.getCConv()));
+    call->setTailCallKind(convertTailCallKindToLLVM(callOp.getTailCallKind()));
     moduleTranslation.setAccessGroupsMetadata(callOp, call);
     moduleTranslation.setAliasScopeMetadata(callOp, call);
     moduleTranslation.setTBAAMetadata(callOp, call);

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -673,3 +673,44 @@ llvm.func @experimental_constrained_fptrunc(%in: f64) {
   %4 = llvm.intr.experimental.constrained.fptrunc %in tonearestaway ignore : f64 to f32
   llvm.return
 }
+
+// CHECK: llvm.func @tail_call_target() -> i32
+llvm.func @tail_call_target() -> i32
+
+// CHECK-LABEL: @test_none
+llvm.func @test_none() -> i32 {
+  // CHECK-NEXT: llvm.call @tail_call_target() : () -> i32
+  %0 = llvm.call none @tail_call_target() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_default
+llvm.func @test_default() -> i32 {
+  // CHECK-NEXT: llvm.call @tail_call_target() : () -> i32
+  %0 = llvm.call @tail_call_target() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_musttail
+llvm.func @test_musttail() -> i32 {
+  // CHECK-NEXT: llvm.call musttail @tail_call_target() : () -> i32
+  %0 = llvm.call musttail @tail_call_target() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_tail
+llvm.func @test_tail() -> i32 {
+  // CHECK-NEXT: llvm.call tail @tail_call_target() : () -> i32
+  %0 = llvm.call tail @tail_call_target() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_notail
+llvm.func @test_notail() -> i32 {
+  // CHECK-NEXT: llvm.call notail @tail_call_target() : () -> i32
+  %0 = llvm.call notail @tail_call_target() : () -> i32
+  llvm.return %0 : i32
+}
+
+
+

--- a/mlir/test/Dialect/LLVMIR/tail-call-kinds.mlir
+++ b/mlir/test/Dialect/LLVMIR/tail-call-kinds.mlir
@@ -1,0 +1,41 @@
+// RUN: mlir-translate -mlir-to-llvmir -split-input-file %s | FileCheck %s
+
+// CHECK: declare i32 @foo()
+llvm.func @foo() -> i32
+
+// CHECK-LABEL: @test_none
+llvm.func @test_none() -> i32 {
+  // CHECK-NEXT: call i32 @foo()
+  %0 = llvm.call none @foo() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_default
+llvm.func @test_default() -> i32 {
+  // CHECK-NEXT: call i32 @foo()
+  %0 = llvm.call @foo() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_musttail
+llvm.func @test_musttail() -> i32 {
+  // CHECK-NEXT: musttail call i32 @foo()
+  %0 = llvm.call musttail @foo() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_tail
+llvm.func @test_tail() -> i32 {
+  // CHECK-NEXT: tail call i32 @foo()
+  %0 = llvm.call tail @foo() : () -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: @test_notail
+llvm.func @test_notail() -> i32 {
+  // CHECK-NEXT: notail call i32 @foo()
+  %0 = llvm.call notail @foo() : () -> i32
+  llvm.return %0 : i32
+}
+
+


### PR DESCRIPTION
The intent of this patch is to enable marking an LLVMDialect CallOp operation as `musttail`. 

There was already a field on the CallInst in LLVM for the type of tail call. I exposed it to MLIR by moving the definition of the tail call kinds to a shared location.